### PR TITLE
refactor exiftool to use the exiftool -json output method...

### DIFF
--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -37,37 +37,32 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
 
   // Handle the response to the callback to hand the metadata back.
   exif.on("close", function () {
-    if (errorMessage)
-    {
+    if (errorMessage) {
       doneGettingMetadata(errorMessage);
     }
-    else
-    {
+    else {
       try {
-
         var jsonResponse = JSON.parse(response);
-
-        /**
-         * exiftool outputs a strange thing: an array with 1 object inside..
-         * convert it to a simple array as that is what this component returned before..
-         */
-
-        if (typeof(jsonResponse[0]) == 'object') {
-          var metaData = [];
-          for (i in jsonResponse[0]) {
-            // make it camelcase..
-            if (i.length > 1) {
-              propName = i.substr(0, 1).toLowerCase() + i.substr(1);
-              metaData[propName] = jsonResponse[0][i];
-            }
-          }
-          doneGettingMetadata(null, metaData);
-        } else {
-          throw new Error('trigger');
-        }
-
-      } catch (Exception) {
+      } catch (e) {
         doneGettingMetadata('Fatal Error: Unable to parse exiftool output.');
+      }
+
+      /**
+       * exiftool outputs a strange thing: an array with 1 object inside..
+       * convert it to a simple array as that is what this component returned before..
+       */
+      if (typeof(jsonResponse[0]) == 'object') {
+        var metaData = [];
+        for (i in jsonResponse[0]) {
+          // make it camelcase..
+          if (i.length > 1) {
+            propName = i.substr(0, 1).toLowerCase() + i.substr(1);
+            metaData[propName] = jsonResponse[0][i];
+          }
+        }
+        doneGettingMetadata(null, metaData);
+      } else {
+        doneGettingMetadata('exiftool returned a wrong format. Did you override the format with arguments?');
       }
 
     }

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -9,15 +9,21 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
   }
 
   // The dash specifies to read data from stdin.
-  var args = (tags === [] ? ['-'] : tags.push("-"));
-  var exif = ChildProcess.spawn('exiftool', tags);
+  var args = [];
+  if (typeof(tags) == 'object' && tags.length > 0) {
+    args = tags;
+  }
+
+  args.push('-json');
+  args.push('-');
+
+  var exif = ChildProcess.spawn('exiftool', args);
 
   //Check for error because of the child process not being found / launched.
   exif.on('error', function (err) {
     doneGettingMetadata('Fatal Error: Unable to load exiftool. ' + err);
   });
 
-  // Read the binary data back
   var response = '';
   var errorMessage = '';
   exif.stdout.on("data", function (data) {
@@ -37,35 +43,29 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
     }
     else
     {
-      // Split the response into lines.
-      response = response.split("\n");
+      try {
 
-      //For each line of the response extract the meta data into a nice associative array
-      var metaData = [];
-      response.forEach(function (responseLine) {
-        var pieces = responseLine.split(": ");
-        //Is this a line with a meta data pair on it?
-        if (pieces.length == 2)
-        {
-          //Turn the plain text data key into a camel case key.
-          var key = pieces[0].trim().split(' ').map(
-            function (tokenInKey, tokenNumber) {
-              if (tokenNumber === 0)
-                return tokenInKey.toLowerCase();
-              else
-                return tokenInKey[0].toUpperCase() + tokenInKey.slice(1);
-            }
-          ).join('');
-          //Trim the value associated with the key to make it nice.
-          var value = pieces[1].trim();
-          if (!isNaN(value))
-          {
-            value = parseFloat(value, 10);
+        var jsonResponse = JSON.parse(response);
+
+        /**
+         * exiftool outputs a strange thing: an array with 1 object inside..
+         * convert it to a simple array as that is what this component returned before..
+         */
+
+        if (typeof(jsonResponse[0]) == 'object') {
+          var metaData = [];
+          for (i in jsonResponse[0]) {
+            metaData[i] = jsonResponse[0][i];
           }
-          metaData[key] = value;
+          doneGettingMetadata(null, metaData);
+        } else {
+          throw new Error('trigger');
         }
-      });
-      doneGettingMetadata(null, metaData);
+
+      } catch (Exception) {
+        doneGettingMetadata('Fatal Error: Unable to parse exiftool output.');
+      }
+
     }
   });
 

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -55,7 +55,11 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
         if (typeof(jsonResponse[0]) == 'object') {
           var metaData = [];
           for (i in jsonResponse[0]) {
-            metaData[i] = jsonResponse[0][i];
+            // make it camelcase..
+            if (i.length > 1) {
+              propName = i.substr(0, 1).toLowerCase() + i.substr(1);
+              metaData[propName] = jsonResponse[0][i];
+            }
           }
           doneGettingMetadata(null, metaData);
         } else {


### PR DESCRIPTION
...makes everything leaner and cleaner. also all tags are returned now - return value structure is the same as before..

@nathanpeck : i'm not sure why this wasn't used in the first place (as exiftool features a json output method for quite some time).. i hope to commit more, i also plan to add tag manipulation methods to the module..
