### PR TITLE
Split on first colon only, instead of all colons

### DIFF
--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -50,12 +50,11 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
       //For each line of the response extract the meta data into a nice associative array
       var metaData = [];
       response.forEach(function (responseLine) {
-        var pieces = responseLine.split(": ");
+        var separatorPos = responseLine.indexOf(': ')
         //Is this a line with a meta data pair on it?
-        if (pieces.length == 2)
-        {
+        if (separatorPos !== -1) {
           //Turn the plain text data key into a camel case key.
-          var key = pieces[0].trim().split(' ').map(
+          var key = responseLine.slice(0, separatorPos).trim().split(' ').map(
             function (tokenInKey, tokenNumber) {
               if (tokenNumber === 0)
                 return tokenInKey.toLowerCase();
@@ -64,7 +63,7 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
             }
           ).join('');
           //Trim the value associated with the key to make it nice.
-          var value = pieces[1].trim();
+          var value = responseLine.slice(separatorPos + 1).trim();
           if (!isNaN(value))
           {
             value = parseFloat(value, 10);


### PR DESCRIPTION
I had a .pdf file with a title that had a colon in it. The module was misbehaving so I added support for values with multiple colons.
