### PR TITLE
Well, is cool to change the comand

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ fs.readFile('./tests/resources/chvrches.jpg', function (err, data) {
 
 ```js
 var exif = require('exiftool');
+// When change the location de exiftool
+exif.command('./my-path/My-binary');
 
 exif.metadata('./tests/resources/chvrches.jpg', function (err, metadata) {
   if (err)
@@ -58,7 +60,7 @@ The properties and contents of the metadata dictionary returned by exiftool will
 __From a JPG:__
 
 ```js
-{ exiftoolVersionNumber: 9.58,
+[ exiftoolVersionNumber: 9.58,
   fileType: 'JPEG',
   mimeType: 'image/jpeg',
   jfifVersion: 1.01,
@@ -71,13 +73,13 @@ __From a JPG:__
   bitsPerSample: 8,
   colorComponents: 3,
   yCbCrSubSampling: 'YCbCr4:2:0 (2 2)',
-  imageSize: '620x413' }
+  imageSize: '620x413' ]
 ```
 
 __From a MOV:__
 
 ```js
-{ exiftoolVersionNumber: 9.58,
+[ exiftoolVersionNumber: 9.58,
   fileType: 'MOV',
   mimeType: 'video/quicktime',
   majorBrand: 'Apple QuickTime (.MOV/QT)',
@@ -172,7 +174,7 @@ __From a MOV:__
   userDataDes: 'In theaters 2012',
   avgBitrate: '457 kbps',
   imageSize: '320x136',
-  rotation: 0 }
+  rotation: 0 ]
 ```
 
 ## Filtering metadata

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -1,87 +1,99 @@
 var ChildProcess = require('child_process');
 
-// Accepts the raw binary content of a file or a path and returns the meta data of the file.
-exports.metadata = function (source, tags, doneGettingMetadata) {
-  // tags is an optional parameter, hence it may be a callback instead.
-  if (typeof tags == 'function') {
-    doneGettingMetadata = tags;
-    tags = [];
-  }
+/*
+var exiftool = require('exiftool')('my-comand-exiftool');
 
-  var usingBinaryData = false;
-  if (typeof source === 'string') {
-    tags.push(source);
-  } else {
-    // The dash specifies to read data from stdin.
-    tags.push("-");
-    usingBinaryData = true;
-  }
-  
-  var exif = ChildProcess.spawn('./vendor/exiftool-9.40/bin/exiftool', tags);
 
-  //Check for error because of the child process not being found / launched.
-  exif.on('error', function (err) {
-    doneGettingMetadata('Fatal Error: Unable to load exiftool. ' + err);
-  });
+*/
 
-  // Read the binary data back
-  var response = '';
-  var errorMessage = '';
-  exif.stdout.on("data", function (data) {
-    response += data;
-  });
+exports = function (comand) {
 
-  // Read an error response back and deal with it.
-  exif.stderr.on("data", function (data) {
-    errorMessage += data.toString();
-  });
+  // Send a object
+  return {
+    // Accepts the raw binary content of a file or a path and returns the meta data of the file.
+    metadata : function (source, tags, doneGettingMetadata) {
+      // tags is an optional parameter, hence it may be a callback instead.
+      if (typeof tags == 'function') {
+        doneGettingMetadata = tags;
+        tags = [];
+      }
 
-  // Handle the response to the callback to hand the metadata back.
-  exif.on("close", function () {
-    if (errorMessage)
-    {
-      doneGettingMetadata(errorMessage);
-    }
-    else
-    {
-      // Split the response into lines.
-      response = response.split("\n");
+      var usingBinaryData = false;
+      if (typeof source === 'string') {
+        tags.push(source);
+      } else {
+        // The dash specifies to read data from stdin.
+        tags.push("-");
+        usingBinaryData = true;
+      }
+      
+      var exif = ChildProcess.spawn( comand || 'exiftool', tags);
 
-      //For each line of the response extract the meta data into a nice associative array
-      var metaData = [];
-      response.forEach(function (responseLine) {
-        var pieces = responseLine.split(": ");
-        //Is this a line with a meta data pair on it?
-        if (pieces.length == 2)
+      //Check for error because of the child process not being found / launched.
+      exif.on('error', function (err) {
+        doneGettingMetadata('Fatal Error: Unable to load exiftool. ' + err);
+      });
+
+      // Read the binary data back
+      var response = '';
+      var errorMessage = '';
+      exif.stdout.on("data", function (data) {
+        response += data;
+      });
+
+      // Read an error response back and deal with it.
+      exif.stderr.on("data", function (data) {
+        errorMessage += data.toString();
+      });
+
+      // Handle the response to the callback to hand the metadata back.
+      exif.on("close", function () {
+        if (errorMessage)
         {
-          //Turn the plain text data key into a camel case key.
-          var key = pieces[0].trim().split(' ').map(
-            function (tokenInKey, tokenNumber) {
-              if (tokenNumber === 0)
-                return tokenInKey.toLowerCase();
-              else
-                return tokenInKey[0].toUpperCase() + tokenInKey.slice(1);
+          doneGettingMetadata(errorMessage);
+        }
+        else
+        {
+          // Split the response into lines.
+          response = response.split("\n");
+
+          //For each line of the response extract the meta data into a nice associative array
+          var metaData = [];
+          response.forEach(function (responseLine) {
+            var pieces = responseLine.split(": ");
+            //Is this a line with a meta data pair on it?
+            if (pieces.length == 2)
+            {
+              //Turn the plain text data key into a camel case key.
+              var key = pieces[0].trim().split(' ').map(
+                function (tokenInKey, tokenNumber) {
+                  if (tokenNumber === 0)
+                    return tokenInKey.toLowerCase();
+                  else
+                    return tokenInKey[0].toUpperCase() + tokenInKey.slice(1);
+                }
+              ).join('');
+              //Trim the value associated with the key to make it nice.
+              var value = pieces[1].trim();
+              if (!isNaN(value))
+              {
+                value = parseFloat(value, 10);
+              }
+              metaData[key] = value;
             }
-          ).join('');
-          //Trim the value associated with the key to make it nice.
-          var value = pieces[1].trim();
-          if (!isNaN(value))
-          {
-            value = parseFloat(value, 10);
-          }
-          metaData[key] = value;
+          });
+          doneGettingMetadata(null, metaData);
         }
       });
-      doneGettingMetadata(null, metaData);
+
+      if (usingBinaryData)
+      {
+        //Give the source binary data to the process which will extract the meta data.
+        exif.stdin.write(source);
+        exif.stdin.end();
+      }
+
+      return exif;
     }
-  });
-
-  if (usingBinaryData)
-  {
-    //Give the source binary data to the process which will extract the meta data.
-    exif.stdin.write(source);
-    exif.stdin.end();
   }
-
-  return exif;
 };

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -1,15 +1,16 @@
 var ChildProcess = require('child_process');
-var comand = 'exiftool';
+var command = 'exiftool';
 /*
 var exiftool = require('exiftool');
 
-// When change the comand
-exiftool('My-New-Comand');
+// When change the command
+exiftool('My-New-command');
 exiftool.metadata(...)
 */
 
-exports.comand = function (c) {
-  comand = c;
+exports.command = function (c) {
+  if(typeof c === 'string')
+    command = c;
 };
 
 // Accepts the raw binary content of a file or a path and returns the meta data of the file.
@@ -29,7 +30,7 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
     usingBinaryData = true;
   }
   
-  var exif = ChildProcess.spawn('exiftool', tags);
+  var exif = ChildProcess.spawn(command || 'exiftool', tags);
 
   //Check for error because of the child process not being found / launched.
   exif.on('error', function (err) {

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -17,7 +17,7 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
     usingBinaryData = true;
   }
   
-  var exif = ChildProcess.spawn('exiftool', tags);
+  var exif = ChildProcess.spawn('./vendor/exiftool-9.40/bin/exiftool', tags);
 
   //Check for error because of the child process not being found / launched.
   exif.on('error', function (err) {

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -1,99 +1,99 @@
 var ChildProcess = require('child_process');
-
+var comand = 'exiftool';
 /*
-var exiftool = require('exiftool')('my-comand-exiftool');
+var exiftool = require('exiftool');
 
-
+// When change the comand
+exiftool('My-New-Comand');
+exiftool.metadata(...)
 */
 
-exports = function (comand) {
+exports.comand = function (c) {
+  comand = c;
+};
 
-  // Send a object
-  return {
-    // Accepts the raw binary content of a file or a path and returns the meta data of the file.
-    metadata : function (source, tags, doneGettingMetadata) {
-      // tags is an optional parameter, hence it may be a callback instead.
-      if (typeof tags == 'function') {
-        doneGettingMetadata = tags;
-        tags = [];
-      }
-
-      var usingBinaryData = false;
-      if (typeof source === 'string') {
-        tags.push(source);
-      } else {
-        // The dash specifies to read data from stdin.
-        tags.push("-");
-        usingBinaryData = true;
-      }
-      
-      var exif = ChildProcess.spawn( comand || 'exiftool', tags);
-
-      //Check for error because of the child process not being found / launched.
-      exif.on('error', function (err) {
-        doneGettingMetadata('Fatal Error: Unable to load exiftool. ' + err);
-      });
-
-      // Read the binary data back
-      var response = '';
-      var errorMessage = '';
-      exif.stdout.on("data", function (data) {
-        response += data;
-      });
-
-      // Read an error response back and deal with it.
-      exif.stderr.on("data", function (data) {
-        errorMessage += data.toString();
-      });
-
-      // Handle the response to the callback to hand the metadata back.
-      exif.on("close", function () {
-        if (errorMessage)
-        {
-          doneGettingMetadata(errorMessage);
-        }
-        else
-        {
-          // Split the response into lines.
-          response = response.split("\n");
-
-          //For each line of the response extract the meta data into a nice associative array
-          var metaData = [];
-          response.forEach(function (responseLine) {
-            var pieces = responseLine.split(": ");
-            //Is this a line with a meta data pair on it?
-            if (pieces.length == 2)
-            {
-              //Turn the plain text data key into a camel case key.
-              var key = pieces[0].trim().split(' ').map(
-                function (tokenInKey, tokenNumber) {
-                  if (tokenNumber === 0)
-                    return tokenInKey.toLowerCase();
-                  else
-                    return tokenInKey[0].toUpperCase() + tokenInKey.slice(1);
-                }
-              ).join('');
-              //Trim the value associated with the key to make it nice.
-              var value = pieces[1].trim();
-              if (!isNaN(value))
-              {
-                value = parseFloat(value, 10);
-              }
-              metaData[key] = value;
-            }
-          });
-          doneGettingMetadata(null, metaData);
-        }
-      });
-
-      if (usingBinaryData)
-      {
-        //Give the source binary data to the process which will extract the meta data.
-        exif.stdin.write(source);
-        exif.stdin.end();
-      }
-
-      return exif;
-    }
+// Accepts the raw binary content of a file or a path and returns the meta data of the file.
+exports.metadata = function (source, tags, doneGettingMetadata) {
+  // tags is an optional parameter, hence it may be a callback instead.
+  if (typeof tags == 'function') {
+    doneGettingMetadata = tags;
+    tags = [];
   }
+
+  var usingBinaryData = false;
+  if (typeof source === 'string') {
+    tags.push(source);
+  } else {
+    // The dash specifies to read data from stdin.
+    tags.push("-");
+    usingBinaryData = true;
+  }
+  
+  var exif = ChildProcess.spawn('exiftool', tags);
+
+  //Check for error because of the child process not being found / launched.
+  exif.on('error', function (err) {
+    doneGettingMetadata('Fatal Error: Unable to load exiftool. ' + err);
+  });
+
+  // Read the binary data back
+  var response = '';
+  var errorMessage = '';
+  exif.stdout.on("data", function (data) {
+    response += data;
+  });
+
+  // Read an error response back and deal with it.
+  exif.stderr.on("data", function (data) {
+    errorMessage += data.toString();
+  });
+
+  // Handle the response to the callback to hand the metadata back.
+  exif.on("close", function () {
+    if (errorMessage)
+    {
+      doneGettingMetadata(errorMessage);
+    }
+    else
+    {
+      // Split the response into lines.
+      response = response.split("\n");
+
+      //For each line of the response extract the meta data into a nice associative array
+      var metaData = [];
+      response.forEach(function (responseLine) {
+        var pieces = responseLine.split(": ");
+        //Is this a line with a meta data pair on it?
+        if (pieces.length == 2)
+        {
+          //Turn the plain text data key into a camel case key.
+          var key = pieces[0].trim().split(' ').map(
+            function (tokenInKey, tokenNumber) {
+              if (tokenNumber === 0)
+                return tokenInKey.toLowerCase();
+              else
+                return tokenInKey[0].toUpperCase() + tokenInKey.slice(1);
+            }
+          ).join('');
+          //Trim the value associated with the key to make it nice.
+          var value = pieces[1].trim();
+          if (!isNaN(value))
+          {
+            value = parseFloat(value, 10);
+          }
+          metaData[key] = value;
+        }
+      });
+      doneGettingMetadata(null, metaData);
+    }
+  });
+
+  if (usingBinaryData)
+  {
+    //Give the source binary data to the process which will extract the meta data.
+    exif.stdin.write(source);
+    exif.stdin.end();
+  }
+
+  return exif;
 };


### PR DESCRIPTION
This will help much when the command console is not directly ie

``` console
$ ./vendedor/0.9.4/exiftool
Syntax:  exiftool [OPTIONS] FILE

Consult the exiftool documentation for a full list of options.
```

How to call would look like

``` js
var exiftool = require('exiftool')('my-comand-exiftool');
exiftool.metadata(...);
```
