### PR TITLE
Use an object instead of an array

### DIFF
--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -1,5 +1,7 @@
 var ChildProcess = require('child_process');
 
+exports.binPath = 'exiftool';
+
 // Accepts the raw binary content of a file or a path and returns the meta data of the file.
 exports.metadata = function (source, tags, doneGettingMetadata) {
   // tags is an optional parameter, hence it may be a callback instead.
@@ -16,8 +18,8 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
     tags.push("-");
     usingBinaryData = true;
   }
-  
-  var exif = ChildProcess.spawn('exiftool', tags);
+
+  var exif = ChildProcess.spawn(this.binPath, tags);
 
   //Check for error because of the child process not being found / launched.
   exif.on('error', function (err) {

--- a/lib/exiftool.js
+++ b/lib/exiftool.js
@@ -47,8 +47,8 @@ exports.metadata = function (source, tags, doneGettingMetadata) {
       // Split the response into lines.
       response = response.split("\n");
 
-      //For each line of the response extract the meta data into a nice associative array
-      var metaData = [];
+      //For each line of the response extract the meta data into an object
+      var metaData = {};
       response.forEach(function (responseLine) {
         var pieces = responseLine.split(": ");
         //Is this a line with a meta data pair on it?


### PR DESCRIPTION
Using arrays as objects results in strange behaviour such as being unable to serialise to JSON
